### PR TITLE
Jinja fix for aws multi-region support

### DIFF
--- a/templates/aws-main.tf.j2
+++ b/templates/aws-main.tf.j2
@@ -3,12 +3,15 @@ provider "aws" {
   version = "{{ cloud_provider_tf_version}}"  
 }
 
+{# Define provider aliases to support multiple regions #}
 {% for name, vnet in vnets.items() %}
-{% if vnet['vnet_network'] is defined %}
+{% if vnet['vnet_network']['region'] is defined %}
+{% if loop.changed(vnet['vnet_network']['region']) %}
 provider "aws" {
   alias  = "{{ vnet['vnet_network']['region'] }}"
   region = "{{ vnet['vnet_network']['region'] }}"
 }
+{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Update aws main jinja template to write out the regional alias provider only if that region hasn't yet been defined. This was causing failure when attempting to create multiple virtual_networks with the same region defined.